### PR TITLE
🔧 config: Agregando `rust-toolchain.toml` 

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.78.0"


### PR DESCRIPTION
Agregando `rust-toolchain.toml` para establecer una versión de Rust más reciente por defecto