### PR TITLE
⬆️ update: Actualizando la versión de SurrealDB 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ poise = { git = "https://github.com/serenity-rs/poise.git", branch= "current" }
 tokio = "1.28.1"
 serenity = "0.12.0"
 serde = "1.0.164"
-surrealdb = { version = "1.1.0", features = ["kv-mem", "rustls"], default-features = false }
+surrealdb = { version = "1.5.1", features = ["kv-mem", "rustls"], default-features = false }
 anyhow = "1.0.68"
 shuttle-runtime= "0.45.0"
 shuttle-serenity = "0.45.0" # Since poise is a serenity command framework, it can run on Shuttle with shuttle-serenity

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.76.0"


### PR DESCRIPTION
Actualizando la versión de SurrealDB a la más reciente y retirando `rust-toolchain.toml` debido a que Shuttle se ha actualizado y ya posee la última versión estable de Rust `(1.78.0)`